### PR TITLE
Fix openai AsyncClient error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ langchain-text-splitters==0.2.0
 sentence-transformers==2.2.2
 faiss-cpu==1.7.4
 openai==1.35.7
+httpx>=0.24.1
 python-frontmatter==1.0.0
 apscheduler==3.10.4
 PyYAML>=5.3


### PR DESCRIPTION
## Summary
- pin httpx to 0.24+ to fix AsyncOpenAI error during startup

## Testing
- `python -m py_compile organize.py index.py main.py`
